### PR TITLE
handle nested annotation in WebAnnotatorLoader 

### DIFF
--- a/webstruct/feature_extraction.py
+++ b/webstruct/feature_extraction.py
@@ -149,7 +149,7 @@ class HtmlTokenizer(object):
         Example:
 
             >>> from webstruct import GateLoader, HtmlTokenizer
-            >>> loader = GateLoader(known_entities=['PER'])
+            >>> loader = GateLoader(known_entities={'PER'})
             >>> html_tokenizer = HtmlTokenizer(replace_html_tags={'b': 'strong'})
             >>> tree = loader.loadbytes(b"<p>hello, <PER>John <b>Doe</b></PER> <br> <PER>Mary</PER> said</p>")
             >>> html_tokens, tags = html_tokenizer.tokenize_single(tree)
@@ -332,7 +332,7 @@ class HtmlFeatureExtractor(BaseEstimator, TransformerMixin):
             >>> from webstruct import GateLoader, HtmlTokenizer, HtmlFeatureExtractor
             >>> from webstruct.features import parent_tag
 
-            >>> loader = GateLoader(known_entities=['PER'])
+            >>> loader = GateLoader(known_entities={'PER'})
             >>> html_tokenizer = HtmlTokenizer()
             >>> feature_extractor = HtmlFeatureExtractor(token_features=[parent_tag])
 

--- a/webstruct/loaders.py
+++ b/webstruct/loaders.py
@@ -56,15 +56,6 @@ class WebAnnotatorLoader(HtmlLoader):
     Class for loading HTML annotated using
     `WebAnnotator <https://github.com/xtannier/WebAnnotator>`_.
 
-    >>> import lxml.html
-    >>> from webstruct import WebAnnotatorLoader
-
-    >>> loader = WebAnnotatorLoader(known_entities={'ORG'})
-    >>> html = b"<html><body><p><span wa-subtypes='' wa-id='227' wa-type='ORG' class='WebAnnotator_org'>Scrapinghub</span> has an <b>office</b> in <span wa-subtypes='' wa-id='228' wa-type='CITY' class='WebAnnotator_org'>Montevideo</span></p></body></html>"
-    >>> tree = loader.loadbytes(html)
-    >>> lxml.html.tostring(tree)
-    '<html><body><p> __START_ORG__ Scrapinghub __END_ORG__  has an <b>office</b> in Montevideo</p></body></html>'
-
     .. note::
 
         Use WebAnnotator's "save format", not "export format".
@@ -119,7 +110,7 @@ class GateLoader(HtmlLoader):
     >>> import lxml.html
     >>> from webstruct import GateLoader
 
-    >>> loader = GateLoader(known_entities=['ORG', 'CITY'])
+    >>> loader = GateLoader(known_entities={'ORG', 'CITY'})
     >>> html = b"<html><body><p><ORG>Scrapinghub</ORG> has an <b>office</b> in <CITY>Montevideo</CITY></p></body></html>"
     >>> tree = loader.loadbytes(html)
     >>> lxml.html.tostring(tree)
@@ -136,20 +127,20 @@ class GateLoader(HtmlLoader):
     def loadbytes(self, data):
         # tags are replaced before parsing data as HTML because
         # GATE's html is invalid
-        data = self._replace_tags(data)
+        data = self._replace_entities(data)
         return super(GateLoader, self).loadbytes(data)
 
-    def _replace_tags(self, html_bytes):
-        # replace requested tags with unified tokens
-        open_re, close_re = self._tag_patterns(self.known_entities)
+    def _replace_entities(self, html_bytes):
+        # replace requested entities with unified tokens
+        open_re, close_re = self._entity_patterns(self.known_entities)
         html_bytes = re.sub(open_re, r' __START_\1__ ', html_bytes)
         html_bytes = re.sub(close_re, r' __END_\1__ ', html_bytes)
         return html_bytes
 
-    def _tag_patterns(self, tags):
-        tags_pattern = '|'.join(list(tags))
-        open_re = re.compile('<(%s)>' % tags_pattern, re.I)
-        close_re = re.compile('</(%s)>' % tags_pattern, re.I)
+    def _entity_patterns(self, entities):
+        entities_pattern = '|'.join(list(entities))
+        open_re = re.compile('<(%s)>' % entities_pattern, re.I)
+        close_re = re.compile('</(%s)>' % entities_pattern, re.I)
         return open_re, close_re
 
 

--- a/webstruct/tests/test_feature_extraction.py
+++ b/webstruct/tests/test_feature_extraction.py
@@ -42,7 +42,7 @@ ANNOTATED_HTML = b"""
 class HtmlTokenizerTest(HtmlTest):
 
     def _load(self):
-        return GateLoader(known_entities=['ORG', 'CITY']).loadbytes(GATE_HTML)
+        return GateLoader(known_entities={'ORG', 'CITY'}).loadbytes(GATE_HTML)
 
     def test_tokenization_doesnt_alter_tree(self):
         src_tree = self._load()

--- a/webstruct/tests/test_loaders.py
+++ b/webstruct/tests/test_loaders.py
@@ -18,6 +18,16 @@ def test_wa_loader():
     assert "wa-" not in res, res
     assert "WA-" not in res, res
 
+
+def test_wa_loader_with_known_entities():
+
+    loader = WebAnnotatorLoader(known_entities={'ORG'})
+    html = b"<html><body><p><span wa-subtypes='' wa-id='227' wa-type='ORG' class='WebAnnotator_org'>Scrapinghub</span> has an <b>office</b> in <span wa-subtypes='' wa-id='228' wa-type='CITY' class='WebAnnotator_org'>Montevideo</span></p></body></html>"
+    tree = loader.loadbytes(html)
+    res = lxml.html.tostring(tree)
+    assert '<html><body><p> __START_ORG__ Scrapinghub __END_ORG__  has an <b>office</b> in Montevideo</p></body></html>' in res
+
+
 def _assert_entities(fragment, known_entities, expected):
 
     ld = WebAnnotatorLoader(known_entities=known_entities)

--- a/webstruct/utils.py
+++ b/webstruct/utils.py
@@ -218,8 +218,8 @@ class LongestMatch(BestMatch):
     """
     Class for finding longest non-overlapping matches in a sequence of tokens.
 
-    >>> known_entities = {'North Las', 'North Las Vegas', 'North Pole', 'Vegas USA', 'Las Vegas', 'USA', "Toronto"}
-    >>> lm = LongestMatch(known_entities)
+    >>> known = {'North Las', 'North Las Vegas', 'North Pole', 'Vegas USA', 'Las Vegas', 'USA', "Toronto"}
+    >>> lm = LongestMatch(known)
     >>> lm.max_length
     3
     >>> tokens = ["Toronto", "to", "North", "Las", "Vegas", "USA"]


### PR DESCRIPTION
some annotations might be nested, e.g. address vs. city/street/zipcode/state. without this change `WebAnnotatorLoader` will get confused about the position of a annotation.
