### PR TITLE
Add tox and Travis CI configs for py27, py33, py34

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,29 @@
 language: python
-python: 2.7
-env:
-  - TOXENV=py27
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=docs
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
 install:
-  - pip install tox
+install:
+  - deps='lxml numpy scipy scikit-learn cython numpydoc'
+  # Download Miniconda
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget http://repo.continuum.io/miniconda/Miniconda-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget http://repo.continuum.io/miniconda/Miniconda3-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+
+  # Replace dep1 dep2 ... with your dependencies
+  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION $deps
+  - source activate test-environment
+  - pip install -r requirements-dev.txt # whatever not installed by conda
+  - python setup.py install
 script:
-  - tox
+  - sh runtests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python: 2.7
+env:
+  - TOXENV=py27
+  - TOXENV=py33
+  - TOXENV=py34
+  - TOXENV=docs
+install:
+  - pip install tox
+script:
+  - tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 nose
 numpydoc
 coverage
+tox

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,1 +1,2 @@
 numpydoc
+sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 lxml
+numpy
+scipy
 scikit-learn >= 0.14
 cython >= 0.19
 -e git+https://github.com/adsva/python-wapiti.git@f7eded69a951c50a461cbe62ecc809e28229eb8f#egg=python-wapiti

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py27, py33, py34, docs
+
+[testenv]
+whitelist_externals = sh
+deps = -r{toxinidir}/requirements-dev.txt
+commands = sh ./runtests.sh {posargs}
+
+[testenv:docs]
+deps = -r{toxinidir}/requirements-doc.txt
+changedir = docs
+commands = sphinx-build -b html . _build/html


### PR DESCRIPTION
Added configs. Set to test pythons 3.3 and 3.4. 3.4 is latest and 3.3 is default for some linux distros.

I added tox config to test locally too.