### PR TITLE
Fix setup.py requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
     ],
-    requires=['sklearn', 'lxml'],
+    install_requires=['six', 'lxml', 'scikit-learn'],
 )


### PR DESCRIPTION
- changed option to "install_requires" (there is no "requires" one)
- added six
- sklearn changed to scikit-learn 'cause thats how it's named
