### PR TITLE
Save to WebAnnotator format using html walk instead of xml sax

### DIFF
--- a/webstruct/tests/test_webannotator.py
+++ b/webstruct/tests/test_webannotator.py
@@ -81,6 +81,34 @@ class WaTitleTest(HtmlTest):
 
 
 class WaConvertTest(HtmlTest):
+    def test_wa_convert_ignore_comments(self):
+        tree = html_document_fromstring(b"""
+        <html>
+            <body>
+                __START_ORG__ a
+                <!--comment-->
+                b __END_ORG__ cool
+            </body>
+        </html>
+        """)
+        wa_tree = webannotator.to_webannotator(tree)
+        wa_tree_str = tostring(wa_tree)
+
+        self.assertHtmlEqual(wa_tree_str, r"""
+        <html>
+            <body>
+                <span class="WebAnnotator_ORG" style="color:#000000; background-color:#33CCFF;" wa-id="0" wa-subtypes="" wa-type="ORG">
+                    a
+                </span>
+                <!--comment-->
+                <span class="WebAnnotator_ORG" style="color:#000000; background-color:#33CCFF;" wa-id="0" wa-subtypes="" wa-type="ORG">
+                    b
+                </span>
+                cool
+            </body>
+            <wa-color id="WA-color-0" bg="#33CCFF" fg="#000000" class="WebAnnotator_ORG" type="ORG"></wa-color>
+        </html>
+        """)
     def test_wa_convert_ignore_style(self):
         tree = html_document_fromstring(b"""
         <html>

--- a/webstruct/tests/test_webannotator.py
+++ b/webstruct/tests/test_webannotator.py
@@ -81,6 +81,102 @@ class WaTitleTest(HtmlTest):
 
 
 class WaConvertTest(HtmlTest):
+    def test_wa_convert_crosstitle(self):
+        tree = html_document_fromstring(b"""
+        <html>
+            <head>
+                <title>
+                     __START_ORG__ a __END_ORG__  b  __START_ORG__ a
+                </title>
+            </head>
+            <body>
+                a __END_ORG__ a
+            </body>
+        </html>
+        """)
+        wa_tree = webannotator.to_webannotator(tree)
+        wa_tree_str = tostring(wa_tree)
+
+        self.assertHtmlEqual(wa_tree_str, r"""
+        <html>
+            <head>
+                <title>
+                    a b a
+                </title>
+            </head>
+            <body>
+                <span class="WebAnnotator_ORG" style="color:#000000; background-color:#33CCFF;" wa-id="1" wa-subtypes="" wa-type="ORG">
+                    a
+                </span>
+                a
+            </body>
+            <wa-color id="WA-color-0" bg="#33CCFF" fg="#000000" class="WebAnnotator_ORG" type="ORG"></wa-color>
+            <wa-title style="box-shadow:0 0 1em black;border:2px solid blue;padding:0.5em;">
+                <span class="WebAnnotator_ORG" style="color:#000000; background-color:#33CCFF;" wa-id="0" wa-subtypes="" wa-type="ORG">
+                    a
+                </span>
+                b
+                <span class="WebAnnotator_ORG" style="color:#000000; background-color:#33CCFF;" wa-id="1" wa-subtypes="" wa-type="ORG">
+                    a
+                </span>
+          </wa-title>
+        </html>
+        """)
+    def test_wa_convert_inner(self):
+        tree = html_document_fromstring(b"""
+        <html>
+          <head>
+            <title> __START_PER__ Hello! __END_PER__  world!</title>
+          </head>
+          <body>
+            <p>
+              __START_ORG__ Scrapinghub
+                <b>Inc has</b>an
+                <b>office</b>in Montevideo __END_ORG__  cool
+            </p>
+          </body>
+        </html>
+        """)
+        wa_tree = webannotator.to_webannotator(tree)
+        wa_tree_str = tostring(wa_tree)
+
+        self.assertHtmlEqual(wa_tree_str, r"""
+        <html>
+          <head>
+            <title>Hello! world!</title>
+          </head>
+          <body>
+            <p>
+              <span class="WebAnnotator_ORG" style="color:#000000; background-color:#FF0000;" wa-id="1" wa-subtypes="" wa-type="ORG">
+                  Scrapinghub
+              </span>
+              <b>
+                <span class="WebAnnotator_ORG" style="color:#000000; background-color:#FF0000;" wa-id="1" wa-subtypes="" wa-type="ORG">
+                    Inc has
+                </span>
+              </b>
+              <span class="WebAnnotator_ORG" style="color:#000000; background-color:#FF0000;" wa-id="1" wa-subtypes="" wa-type="ORG">
+                  an
+              </span>
+              <b>
+                  <span class="WebAnnotator_ORG" style="color:#000000; background-color:#FF0000;" wa-id="1" wa-subtypes="" wa-type="ORG">
+                      office
+                  </span>
+              </b>
+              <span class="WebAnnotator_ORG" style="color:#000000; background-color:#FF0000;" wa-id="1" wa-subtypes="" wa-type="ORG">
+                  in Montevideo
+              </span>
+               cool
+            </p>
+          </body>
+          <wa-color id="WA-color-0" bg="#33CCFF" fg="#000000" class="WebAnnotator_PER" type="PER"></wa-color>
+          <wa-color id="WA-color-1" bg="#FF0000" fg="#000000" class="WebAnnotator_ORG" type="ORG"></wa-color>
+          <wa-title style="box-shadow:0 0 1em black;border:2px solid blue;padding:0.5em;">
+            <span class="WebAnnotator_PER" style="color:#000000; background-color:#33CCFF;" wa-id="0" wa-subtypes="" wa-type="PER">Hello!</span> world!
+          </wa-title>
+        </html>
+        """)
+
     def test_wa_convert(self):
         tree = html_document_fromstring(b"""
         <html>
@@ -91,7 +187,7 @@ class WaConvertTest(HtmlTest):
             <p>
               __START_ORG__ Scrapinghub
                 <b>Inc __END_ORG__  has</b>an
-                <b>__START_CITY__office</b>in Montevideo __END_CITY__   __START_ORG__ SH __END_ORG__
+                <b> __START_CITY__ office</b>in Montevideo __END_CITY__   __START_ORG__ SH __END_ORG__ cool
             </p>
           </body>
         </html>
@@ -99,7 +195,7 @@ class WaConvertTest(HtmlTest):
         wa_tree = webannotator.to_webannotator(tree)
         wa_tree_str = tostring(wa_tree)
 
-        self.assertHtmlEqual(wa_tree_str, br"""
+        self.assertHtmlEqual(wa_tree_str, r"""
         <html>
           <head>
             <title>Hello! world!</title>
@@ -110,7 +206,7 @@ class WaConvertTest(HtmlTest):
               <b><span class="WebAnnotator_ORG" style="color:#000000; background-color:#FF0000;" wa-id="1" wa-subtypes="" wa-type="ORG">Inc</span> has</b>an
               <b><span class="WebAnnotator_CITY" style="color:#000000; background-color:#33FF33;" wa-id="2" wa-subtypes="" wa-type="CITY">office</span></b>
               <span class="WebAnnotator_CITY" style="color:#000000; background-color:#33FF33;" wa-id="2" wa-subtypes="" wa-type="CITY">in Montevideo</span>
-              <span class="WebAnnotator_ORG" style="color:#000000; background-color:#FF0000;" wa-id="3" wa-subtypes="" wa-type="ORG">SH</span>
+              <span class="WebAnnotator_ORG" style="color:#000000; background-color:#FF0000;" wa-id="3" wa-subtypes="" wa-type="ORG">SH</span> cool
             </p>
           </body>
           <wa-color id="WA-color-0" bg="#33CCFF" fg="#000000" class="WebAnnotator_PER" type="PER"></wa-color>
@@ -129,7 +225,7 @@ class WaConvertTest(HtmlTest):
         wa_tree = webannotator.to_webannotator(tree)
         wa_tree_str = tostring(wa_tree)
 
-        self.assertHtmlEqual(wa_tree_str, br"""
+        self.assertHtmlEqual(wa_tree_str, r"""
         <html>
           <body>
             <p>

--- a/webstruct/tests/test_webannotator.py
+++ b/webstruct/tests/test_webannotator.py
@@ -81,6 +81,44 @@ class WaTitleTest(HtmlTest):
 
 
 class WaConvertTest(HtmlTest):
+    def test_wa_convert_ignore_style(self):
+        tree = html_document_fromstring(b"""
+        <html>
+            <body>
+                __START_ORG__ a
+                <script>
+                    wowowojavascript
+                </script>
+                <style>
+                    wowowocss
+                </style>
+                b __END_ORG__ cool
+            </body>
+        </html>
+        """)
+        wa_tree = webannotator.to_webannotator(tree)
+        wa_tree_str = tostring(wa_tree)
+
+        self.assertHtmlEqual(wa_tree_str, r"""
+        <html>
+            <body>
+                <span class="WebAnnotator_ORG" style="color:#000000; background-color:#33CCFF;" wa-id="0" wa-subtypes="" wa-type="ORG">
+                    a
+                </span>
+                <script>
+                    wowowojavascript
+                </script>
+                <style>
+                    wowowocss
+                </style>
+                <span class="WebAnnotator_ORG" style="color:#000000; background-color:#33CCFF;" wa-id="0" wa-subtypes="" wa-type="ORG">
+                    b
+                </span>
+                cool
+            </body>
+            <wa-color id="WA-color-0" bg="#33CCFF" fg="#000000" class="WebAnnotator_ORG" type="ORG"></wa-color>
+        </html>
+        """)
     def test_wa_convert_crosstitle(self):
         tree = html_document_fromstring(b"""
         <html>

--- a/webstruct/tests/test_webannotator.py
+++ b/webstruct/tests/test_webannotator.py
@@ -109,6 +109,7 @@ class WaConvertTest(HtmlTest):
             <wa-color id="WA-color-0" bg="#33CCFF" fg="#000000" class="WebAnnotator_ORG" type="ORG"></wa-color>
         </html>
         """)
+
     def test_wa_convert_ignore_style(self):
         tree = html_document_fromstring(b"""
         <html>
@@ -147,6 +148,7 @@ class WaConvertTest(HtmlTest):
             <wa-color id="WA-color-0" bg="#33CCFF" fg="#000000" class="WebAnnotator_ORG" type="ORG"></wa-color>
         </html>
         """)
+
     def test_wa_convert_crosstitle(self):
         tree = html_document_fromstring(b"""
         <html>
@@ -188,6 +190,7 @@ class WaConvertTest(HtmlTest):
           </wa-title>
         </html>
         """)
+
     def test_wa_convert_inner(self):
         tree = html_document_fromstring(b"""
         <html>

--- a/webstruct/webannotator.py
+++ b/webstruct/webannotator.py
@@ -222,12 +222,12 @@ def enclose(tasks, entity_colors):
     remainder = source[:first.position]
 
     nodes = list()
-    for number, (start, end, _id) in enumerate(tasks):
+    for idx, (start, end, _id) in enumerate(tasks):
 
         limit = len(source)
-        is_last = number == len(tasks) - 1
+        is_last = idx == len(tasks) - 1
         if not is_last:
-            limit = tasks[number + 1][0].position
+            limit = tasks[idx + 1][0].position
 
         tag = start.tag
         text = source[start.position + start.length:end.position]
@@ -259,8 +259,8 @@ def enclose(tasks, entity_colors):
         parent = element
         shift = 0
 
-    for number, node in enumerate(nodes):
-        parent.insert(number + shift, node)
+    for idx, node in enumerate(nodes):
+        parent.insert(idx + shift, node)
 
 
 def fabricate_start(element, is_tail, tag):

--- a/webstruct/webannotator.py
+++ b/webstruct/webannotator.py
@@ -412,7 +412,7 @@ def to_webannotator(tree, entity_colors=None, url=None):
     starts.sort(key=lambda t: (t.dfs_number, t.position))
     ends.sort(key=lambda t: (t.dfs_number, t.position))
 
-    dfs_order = (max(n for n in ordered.values()) + 1) * [None]
+    dfs_order = (max(ordered.values()) + 1) * [None]
     for text_node, dfs_number in ordered.items():
         dfs_order[dfs_number] = text_node
 

--- a/webstruct/webannotator.py
+++ b/webstruct/webannotator.py
@@ -357,6 +357,9 @@ def to_webannotator(tree, entity_colors=None, url=None):
     starts = [s for s in translate_to_dfs(starts, ordered)]
     ends = [e for e in translate_to_dfs(ends, ordered)]
 
+    starts.sort(key = lambda t:(t.dfs_number, t.position))
+    ends.sort(key = lambda t:(t.dfs_number, t.position))
+
     dfs_order = (max(n for n in ordered.values()) + 1) * [None]
     for text_node, dfs_number in ordered.items():
         dfs_order[dfs_number] = text_node

--- a/webstruct/webannotator.py
+++ b/webstruct/webannotator.py
@@ -322,6 +322,28 @@ def _find_enclosures(starts, ends, dfs_order):
         fictive_start = _fabricate_start(end.element, end.is_tail, end.tag)
         yield fictive_start, end, _id
 
+def _enumerate_nodes_in_dfs_order(root):
+    # traverse tree in DFS manner
+    # each text is first child
+    # each tail is last
+    ordered = dict()
+    number = 0
+    for action, element in etree.iterwalk(root, events=('start', 'end')):
+
+        if action == 'end':
+            is_tail = True
+            ordered[(element, is_tail)] = number
+            number = number + 1  # for tail
+
+        if action == 'start':
+            is_tail = False
+            ordered[(element, is_tail)] = number
+            number = number + 1  # for text
+            number = number + 1  # for element
+
+    return ordered
+
+
 def to_webannotator(tree, entity_colors=None, url=None):
     """
     Convert a tree loaded by one of WebStruct loaders to WebAnnotator format.
@@ -373,24 +395,7 @@ def to_webannotator(tree, entity_colors=None, url=None):
     if len(ends) != len(starts):
         raise ValueError('len(ends) != len(starts)')
 
-    # traverse tree in DFS manner
-    # each text is first child
-    # each tail is last
-    ordered = dict()
-    number = 0
-    for action, element in etree.iterwalk(root, events=('start', 'end')):
-
-        if action == 'end':
-            is_tail = True
-            ordered[(element, is_tail)] = number
-            number = number + 1  # for tail
-
-        if action == 'start':
-            is_tail = False
-            ordered[(element, is_tail)] = number
-            number = number + 1  # for text
-            number = number + 1  # for element
-
+    ordered = _enumerate_nodes_in_dfs_order(root)
     starts = [s for s in _translate_to_dfs(starts, ordered)]
     ends = [e for e in _translate_to_dfs(ends, ordered)]
 

--- a/webstruct/webannotator.py
+++ b/webstruct/webannotator.py
@@ -343,27 +343,7 @@ def _enumerate_nodes_in_dfs_order(root):
 
     return ordered
 
-
-def to_webannotator(tree, entity_colors=None, url=None):
-    """
-    Convert a tree loaded by one of WebStruct loaders to WebAnnotator format.
-
-    If you want a predictable colors assignment use ``entity_colors`` argument;
-    it should be a mapping ``{'entity_name': (fg, bg, entity_idx)}``;
-    entity names should be lowercased. You can use :class:`EntityColors`
-    to generate this mapping automatically:
-
-    >>> from webstruct.webannotator import EntityColors, to_webannotator
-    >>> # trees = ...
-    >>> entity_colors = EntityColors()
-    >>> wa_trees = [to_webannotator(tree, entity_colors) for tree in trees]  # doctest: +SKIP
-
-    """
-    if not entity_colors:
-        entity_colors = EntityColors()
-
-    root = deepcopy(tree)
-
+def _find_tag_limits(root):
     START_RE = re.compile(r' __START_(\w+)__ ')
     END_RE = re.compile(r' __END_(\w+)__ ')
 
@@ -391,6 +371,31 @@ def to_webannotator(tree, entity_colors=None, url=None):
                                             length=match.end() - match.start(),
                                             is_tail=is_tail,
                                             dfs_number=-1))
+
+    return starts, ends
+
+
+def to_webannotator(tree, entity_colors=None, url=None):
+    """
+    Convert a tree loaded by one of WebStruct loaders to WebAnnotator format.
+
+    If you want a predictable colors assignment use ``entity_colors`` argument;
+    it should be a mapping ``{'entity_name': (fg, bg, entity_idx)}``;
+    entity names should be lowercased. You can use :class:`EntityColors`
+    to generate this mapping automatically:
+
+    >>> from webstruct.webannotator import EntityColors, to_webannotator
+    >>> # trees = ...
+    >>> entity_colors = EntityColors()
+    >>> wa_trees = [to_webannotator(tree, entity_colors) for tree in trees]  # doctest: +SKIP
+
+    """
+    if not entity_colors:
+        entity_colors = EntityColors()
+
+    root = deepcopy(tree)
+
+    starts, ends = _find_tag_limits(root)
 
     if len(ends) != len(starts):
         raise ValueError('len(ends) != len(starts)')

--- a/webstruct/webannotator.py
+++ b/webstruct/webannotator.py
@@ -13,6 +13,7 @@ from copy import deepcopy
 from collections import defaultdict, OrderedDict, namedtuple
 from lxml import etree
 from lxml.etree import Element, LXML_VERSION
+import six
 
 from webstruct.utils import html_document_fromstring
 
@@ -374,6 +375,9 @@ def to_webannotator(tree, entity_colors=None, url=None):
                 continue
 
             element, is_tail = text_node
+
+            if not isinstance(element.tag, six.string_types) and not isinstance(element.tag, six.text_type):
+                continue
 
             if element.tag in ['script', 'style']:
                 continue

--- a/webstruct/webannotator.py
+++ b/webstruct/webannotator.py
@@ -186,18 +186,18 @@ def _set_base(tree, baseurl):
     head = _ensure_head(tree)
     head.insert(0, Element("base", href=baseurl))
 
-TagPosition = namedtuple('TagPosition', ['element',
-                                         'tag',
-                                         'position',
-                                         'length',
-                                         'is_tail',
-                                         'dfs_number'])
+_TagPosition = namedtuple('_TagPosition', ['element',
+                                           'tag',
+                                           'position',
+                                           'length',
+                                           'is_tail',
+                                           'dfs_number'])
 
 
 def translate_to_dfs(positions, ordered):
     for position in positions:
         number = ordered[(position.element, position.is_tail)]
-        yield TagPosition(element=position.element,
+        yield _TagPosition(element=position.element,
                           tag=position.tag,
                           position=position.position,
                           length=position.length,
@@ -264,7 +264,7 @@ def enclose(tasks, entity_colors):
 
 
 def fabricate_start(element, is_tail, tag):
-    return TagPosition(element=element,
+    return _TagPosition(element=element,
                        tag=tag,
                        position=0,
                        length=0,
@@ -281,7 +281,7 @@ def fabricate_end(element, is_tail, tag):
     if target:
         length = len(target)
 
-    return TagPosition(element=element,
+    return _TagPosition(element=element,
                        tag=tag,
                        position=length,
                        length=0,
@@ -329,7 +329,7 @@ def to_webannotator(tree, entity_colors=None, url=None):
                 if not match:
                     continue
 
-                storage.append(TagPosition(element=element,
+                storage.append(_TagPosition(element=element,
                                            tag=match.group(1),
                                            position=match.start(),
                                            length=match.end() - match.start(),

--- a/webstruct/webannotator.py
+++ b/webstruct/webannotator.py
@@ -263,7 +263,7 @@ def enclose(tasks, entity_colors):
         parent.insert(idx + shift, node)
 
 
-def fabricate_start(element, is_tail, tag):
+def _fabricate_start(element, is_tail, tag):
     return _TagPosition(element=element,
                         tag=tag,
                         position=0,
@@ -272,7 +272,7 @@ def fabricate_start(element, is_tail, tag):
                         dfs_number=0)
 
 
-def fabricate_end(element, is_tail, tag):
+def _fabricate_end(element, is_tail, tag):
     target = element.text
     if is_tail:
         target = element.tail
@@ -390,14 +390,14 @@ def to_webannotator(tree, entity_colors=None, url=None):
             if element.tag in ['script', 'style']:
                 continue
 
-            fictive_start = fabricate_start(element, is_tail, start.tag)
-            fictive_end = fabricate_end(element, is_tail, start.tag)
+            fictive_start = _fabricate_start(element, is_tail, start.tag)
+            fictive_end = _fabricate_end(element, is_tail, start.tag)
             tasks.append((fictive_start, fictive_end, _id))
 
-        fictive_end = fabricate_end(start.element, start.is_tail, start.tag)
+        fictive_end = _fabricate_end(start.element, start.is_tail, start.tag)
         tasks.append((start, fictive_end, _id))
 
-        fictive_start = fabricate_start(end.element, end.is_tail, end.tag)
+        fictive_start = _fabricate_start(end.element, end.is_tail, end.tag)
         tasks.append((fictive_start, end, _id))
 
     def byelement(rec): return (rec[0].element, rec[0].is_tail)

--- a/webstruct/webannotator.py
+++ b/webstruct/webannotator.py
@@ -325,9 +325,6 @@ def _find_enclosures(starts, ends, dfs_order):
 
 
 def _enumerate_nodes_in_dfs_order(root):
-    # traverse tree in DFS manner
-    # each text is first child
-    # each tail is last
     ordered = dict()
     number = 0
     for action, element in etree.iterwalk(root, events=('start', 'end')):
@@ -398,6 +395,13 @@ def to_webannotator(tree, entity_colors=None, url=None):
 
     root = deepcopy(tree)
 
+    # We walk the DOM tree in depth first order and number all nodes.
+    # Also we number each text node as first child and tail node as last child.
+    # So when we have start tag in node with number n
+    # and stop tag in node with number n+m,
+    # we should annotate all nodes with numbers n+i, where i in range [1,m).
+    # All these nodes are located on the rigth and below the start
+    # and on the left and below the end.
     starts, ends = _find_tag_limits(root)
 
     if len(ends) != len(starts):

--- a/webstruct/webannotator.py
+++ b/webstruct/webannotator.py
@@ -288,6 +288,7 @@ def _fabricate_end(element, is_tail, tag):
                         is_tail=is_tail,
                         dfs_number=0)
 
+
 def _find_enclosures(starts, ends, dfs_order):
 
     for _id, (start, end) in enumerate(zip(starts, ends)):
@@ -322,6 +323,7 @@ def _find_enclosures(starts, ends, dfs_order):
         fictive_start = _fabricate_start(end.element, end.is_tail, end.tag)
         yield fictive_start, end, _id
 
+
 def _enumerate_nodes_in_dfs_order(root):
     # traverse tree in DFS manner
     # each text is first child
@@ -342,6 +344,7 @@ def _enumerate_nodes_in_dfs_order(root):
             number = number + 1  # for element
 
     return ordered
+
 
 def _find_tag_limits(root):
     START_RE = re.compile(r' __START_(\w+)__ ')
@@ -415,7 +418,8 @@ def to_webannotator(tree, entity_colors=None, url=None):
 
     def byelement(rec): return (rec[0].element, rec[0].is_tail)
 
-    to_enclosure.sort(key=lambda rec: (ordered[byelement(rec)], rec[0].position))
+    to_enclosure.sort(key=lambda rec: (ordered[byelement(rec)],
+                                       rec[0].position))
     for _, enclosures in itertools.groupby(to_enclosure, byelement):
         enclosures = [e for e in enclosures]
         _enclose(enclosures, entity_colors)

--- a/webstruct/webannotator.py
+++ b/webstruct/webannotator.py
@@ -205,11 +205,11 @@ def _translate_to_dfs(positions, ordered):
                            dfs_number=number)
 
 
-def _enclose(tasks, entity_colors):
-    if not tasks:
+def _enclose(to_enclosure, entity_colors):
+    if not to_enclosure:
         return
 
-    first = tasks[0][0]
+    first = to_enclosure[0][0]
     element = first.element
     is_tail = first.is_tail
     source = element.text
@@ -222,12 +222,12 @@ def _enclose(tasks, entity_colors):
     remainder = source[:first.position]
 
     nodes = list()
-    for idx, (start, end, _id) in enumerate(tasks):
+    for idx, (start, end, _id) in enumerate(to_enclosure):
 
         limit = len(source)
-        is_last = idx == len(tasks) - 1
+        is_last = idx == len(to_enclosure) - 1
         if not is_last:
-            limit = tasks[idx + 1][0].position
+            limit = to_enclosure[idx + 1][0].position
 
         tag = start.tag
         text = source[start.position + start.length:end.position]
@@ -401,12 +401,12 @@ def to_webannotator(tree, entity_colors=None, url=None):
     for text_node, dfs_number in ordered.items():
         dfs_order[dfs_number] = text_node
 
-    tasks = [e for e in _find_enclosures(starts, ends, dfs_order)]
+    to_enclosure = [e for e in _find_enclosures(starts, ends, dfs_order)]
 
     def byelement(rec): return (rec[0].element, rec[0].is_tail)
 
-    tasks.sort(key=lambda rec: (ordered[byelement(rec)], rec[0].position))
-    for _, enclosures in itertools.groupby(tasks, byelement):
+    to_enclosure.sort(key=lambda rec: (ordered[byelement(rec)], rec[0].position))
+    for _, enclosures in itertools.groupby(to_enclosure, byelement):
         enclosures = [e for e in enclosures]
         _enclose(enclosures, entity_colors)
 

--- a/webstruct/webannotator.py
+++ b/webstruct/webannotator.py
@@ -194,15 +194,15 @@ _TagPosition = namedtuple('_TagPosition', ['element',
                                            'dfs_number'])
 
 
-def translate_to_dfs(positions, ordered):
+def _translate_to_dfs(positions, ordered):
     for position in positions:
         number = ordered[(position.element, position.is_tail)]
         yield _TagPosition(element=position.element,
-                          tag=position.tag,
-                          position=position.position,
-                          length=position.length,
-                          is_tail=position.is_tail,
-                          dfs_number=number)
+                           tag=position.tag,
+                           position=position.position,
+                           length=position.length,
+                           is_tail=position.is_tail,
+                           dfs_number=number)
 
 
 def enclose(tasks, entity_colors):
@@ -265,11 +265,11 @@ def enclose(tasks, entity_colors):
 
 def fabricate_start(element, is_tail, tag):
     return _TagPosition(element=element,
-                       tag=tag,
-                       position=0,
-                       length=0,
-                       is_tail=is_tail,
-                       dfs_number=0)
+                        tag=tag,
+                        position=0,
+                        length=0,
+                        is_tail=is_tail,
+                        dfs_number=0)
 
 
 def fabricate_end(element, is_tail, tag):
@@ -282,11 +282,11 @@ def fabricate_end(element, is_tail, tag):
         length = len(target)
 
     return _TagPosition(element=element,
-                       tag=tag,
-                       position=length,
-                       length=0,
-                       is_tail=is_tail,
-                       dfs_number=0)
+                        tag=tag,
+                        position=length,
+                        length=0,
+                        is_tail=is_tail,
+                        dfs_number=0)
 
 def to_webannotator(tree, entity_colors=None, url=None):
     """
@@ -330,11 +330,11 @@ def to_webannotator(tree, entity_colors=None, url=None):
                     continue
 
                 storage.append(_TagPosition(element=element,
-                                           tag=match.group(1),
-                                           position=match.start(),
-                                           length=match.end() - match.start(),
-                                           is_tail=is_tail,
-                                           dfs_number=-1))
+                                            tag=match.group(1),
+                                            position=match.start(),
+                                            length=match.end() - match.start(),
+                                            is_tail=is_tail,
+                                            dfs_number=-1))
 
     if len(ends) != len(starts):
         raise ValueError('len(ends) != len(starts)')
@@ -357,8 +357,8 @@ def to_webannotator(tree, entity_colors=None, url=None):
             number = number + 1  # for text
             number = number + 1  # for element
 
-    starts = [s for s in translate_to_dfs(starts, ordered)]
-    ends = [e for e in translate_to_dfs(ends, ordered)]
+    starts = [s for s in _translate_to_dfs(starts, ordered)]
+    ends = [e for e in _translate_to_dfs(ends, ordered)]
 
     starts.sort(key=lambda t: (t.dfs_number, t.position))
     ends.sort(key=lambda t: (t.dfs_number, t.position))

--- a/webstruct/webannotator.py
+++ b/webstruct/webannotator.py
@@ -304,10 +304,8 @@ def _find_enclosures(starts, ends, dfs_order):
                 continue
 
             element, is_tail = text_node
-            is_string = isinstance(element.tag, six.string_types)
-            is_text = isinstance(element.tag, six.text_type)
 
-            if not is_string and not is_text:
+            if not isinstance(element.tag, six.string_types):
                 continue
 
             if element.tag in ['script', 'style']:

--- a/webstruct/webannotator.py
+++ b/webstruct/webannotator.py
@@ -205,7 +205,7 @@ def _translate_to_dfs(positions, ordered):
                            dfs_number=number)
 
 
-def enclose(tasks, entity_colors):
+def _enclose(tasks, entity_colors):
     if not tasks:
         return
 
@@ -405,7 +405,7 @@ def to_webannotator(tree, entity_colors=None, url=None):
     tasks.sort(key=lambda rec: (ordered[byelement(rec)], rec[0].position))
     for _, enclosures in itertools.groupby(tasks, byelement):
         enclosures = [e for e in enclosures]
-        enclose(enclosures, entity_colors)
+        _enclose(enclosures, entity_colors)
 
     _copy_title(root)
     _add_wacolor_elements(root, entity_colors)


### PR DESCRIPTION
Using html walk we can preserve html comments and do not annotate script/style tags