### PR TITLE
Wapiti for webstruct

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,5 @@ pytest-cov
 numpydoc
 coverage
 tox
+joblib
+dawg

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ lxml
 numpy
 scipy
 scikit-learn >= 0.14
--e git+https://github.com/adsva/python-wapiti.git@f7eded69a951c50a461cbe62ecc809e28229eb8f#egg=python-wapiti
+-e git+https://github.com/adsva/python-wapiti.git#egg=libwapiti
 python-crfsuite >= 0.8.4
 sklearn-crfsuite >= 0.3.3
 tldextract

--- a/webstruct/model_benchmark.py
+++ b/webstruct/model_benchmark.py
@@ -1,0 +1,35 @@
+import sys
+import os.path
+import glob
+import timeit
+import functools
+
+import joblib
+
+
+def predict(model, bodies):
+    for body in bodies:
+        model.extract_raw(body)
+
+
+def main():
+    path = os.path.join(os.path.dirname(__file__) ,
+                        ".." ,
+                        "webstruct_data",
+                        "corpus/business_pages/wa/*.html")
+
+
+    paths = sorted(glob.glob(path))
+    bodies = list()
+    for p in paths:
+        with open(p, 'rb') as reader:
+            bodies.append(reader.read())
+
+    model = joblib.load(sys.argv[1])
+    print(timeit.timeit(functools.partial(predict, model, bodies),
+                        setup='gc.enable()',
+                        number=3))
+
+
+if __name__ == "__main__":
+    main()

--- a/webstruct/wapiti.py
+++ b/webstruct/wapiti.py
@@ -76,13 +76,26 @@ def create_wapiti_pipeline(model_filename=None,
 
 def merge_top_n(chains):
     """
-    >>>
+    non-overlap
     >>> chains = [ ['B-PER', 'O'     ],
     ...            ['O'    , 'B-FUNC'] ]
 
     >>> merge_top_n(chains)
     ['B-PER', 'B-FUNC']
 
+    partially overlap
+    >>> chains = [ ['B-PER', 'I-PER', 'O'    ],
+    ...            ['O'    , 'B-PER', 'I-PER'] ]
+
+    >>> merge_top_n(chains)
+    ['B-PER', 'I-PER', 'O']
+
+    fully overlap
+    >>> chains = [ ['B-PER', 'I-PER'],
+    ...            ['B-ORG', 'I-ORG'] ]
+
+    >>> merge_top_n(chains)
+    ['B-PER', 'I-PER']
     """
     ret = copy.copy(chains[0])
     for chain in chains[1:]:

--- a/webstruct/wapiti.py
+++ b/webstruct/wapiti.py
@@ -209,7 +209,7 @@ class WapitiCRF(BaseSequenceClassifier):
         """
         model = self._get_python_wapiti_model()
         sequences = self._to_wapiti_sequences(X)
-        return [model.label_sequence(seq).splitlines() for seq in sequences]
+        return [model.label_sequence(seq).decode(model.encoding).splitlines() for seq in sequences]
 
     def run_wapiti(self, args):
         """ Run ``wapiti`` binary in a subprocess """

--- a/webstruct/wapiti.py
+++ b/webstruct/wapiti.py
@@ -76,6 +76,11 @@ def create_wapiti_pipeline(model_filename=None,
 
 def merge_top_n(chains):
     """
+    Take first (most probable) as base for resulting chain
+    and merge other N-1 chains one by one
+    Entities in next merged chain, which has any overlap
+    with entities in resulting chain, just ignored
+
     non-overlap
     >>> chains = [ ['B-PER', 'O'     ],
     ...            ['O'    , 'B-FUNC'] ]


### PR DESCRIPTION
This commits return wapiti as functional alternative for a crfsuite and add top-N for wapiti. Reason for wapiti to be functional, as it is supports top-N prediction. 
Instead of one (top-1) prediction for a chain of tokens give N most probable predictions. After this  we merge N predictions into one. This trick improves recall.
Also I added benchmark to test speed performance of models. Here are results for contacts model prediction timings of Contacts model from example.
for top1 132, 135, 145 s
for top5 145, 149, 145 s
for top10 179, 182, 180 s
